### PR TITLE
Fixing logic around VFR-MVFR-IFR-LIFR for Sky Coverage

### DIFF
--- a/src/usr/local/bin/airpuff/airpuff-tester.py
+++ b/src/usr/local/bin/airpuff/airpuff-tester.py
@@ -105,13 +105,13 @@ for count in range(0, met_json_results):
         ceil_m            = met_json['data'][count]['ceiling']['meters_agl']
     except:
         ceil_m            = 3,657.6
-    if ceil_ft > 3000:
+    if ceil_ft >= 3000:
         ceil_class = "vfr_std"
-    elif 1000 < ceil_ft <= 3000:
+    elif 1000 <= ceil_ft < 3000:
         ceil_class = "mvfr_std"
-    elif 500 < ceil_ft <= 1000:
+    elif 500 <= ceil_ft < 1000:
         ceil_class = "ifr_std"
-    elif ceil_ft <= 500:
+    elif ceil_ft < 500:
         ceil_class = "lifr_std"
     cld_len           = len(met_json['data'][count]['clouds'])
 #   for cld_ct in range(0, cld_len):


### PR DESCRIPTION
Test results:

$ python3 ./airpuff-tester.py "work" ksuu
...
    <td class="**mvfr_std**">OVC 1000</td>

- 'mvfr_std' was previously showing as IFR not MVFR.
- This logic matches the same for Visibility (diff values, of course)